### PR TITLE
Add GPIO to Model and Tests

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -4,17 +4,25 @@ set -euxo pipefail
 
 cd g4/model
 
-cargo r
+# this takes a long time now so let's skip it
+# cargo r
 cargo clippy -- --deny warnings
 
 cd ../out
 
 VARIANTS=("g431" "g441" "g474" "g484")
+TESTS=("cordic" "gpio")
 
 for VARIANT in "${VARIANTS[@]}"; do
     cargo build --features "$VARIANT"
-    cargo build --test cordic --features "$VARIANT"
+    for TEST in "${TESTS[@]}"; do
+        cargo build --test "$TEST" --features "$VARIANT"
+    done
+
     cargo clippy --features "$VARIANT" -- --deny warnings
+    for TEST in "${TESTS[@]}"; do
+        cargo clippy --test "$TEST" --features "$VARIANT" -- --deny warnings
+    done
 done
 
 # all tests are HIL

--- a/g4/model/Cargo.lock
+++ b/g4/model/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
 [[package]]
 name = "ir"
 version = "0.1.0"
-source = "git+https://github.com/adinack/proto-hal?branch=main#e071e242a055f863acb2eb213a58cccf54841ad5"
+source = "git+https://github.com/adinack/proto-hal?branch=main#a9ca6f2310d803998921bb72e0d72b331fc6ccf5"
 dependencies = [
  "Inflector",
  "colored",
@@ -230,7 +230,7 @@ checksum = "302c525e16613efd9c9a684c096503d9dc662f7feb6b6c40e59303b4e2c4c113"
 [[package]]
 name = "proto-hal-build"
 version = "0.1.0"
-source = "git+https://github.com/adinack/proto-hal?branch=main#e071e242a055f863acb2eb213a58cccf54841ad5"
+source = "git+https://github.com/adinack/proto-hal?branch=main#a9ca6f2310d803998921bb72e0d72b331fc6ccf5"
 dependencies = [
  "colored",
  "ir",

--- a/g4/model/src/cordic.rs
+++ b/g4/model/src/cordic.rs
@@ -1,6 +1,6 @@
-mod csr;
-mod rdata;
-mod wdata;
+pub mod csr;
+pub mod rdata;
+pub mod wdata;
 
 use proto_hal_build::ir::structures::{entitlement::Entitlement, peripheral::Peripheral};
 

--- a/g4/model/src/gpio.rs
+++ b/g4/model/src/gpio.rs
@@ -1,0 +1,74 @@
+pub mod afr;
+pub mod brr;
+pub mod bsrr;
+pub mod idr;
+pub mod lckr;
+pub mod moder;
+pub mod odr;
+pub mod ospeedr;
+pub mod otyper;
+pub mod pupdr;
+
+use proto_hal_build::ir::structures::{entitlement::Entitlement, peripheral::Peripheral};
+
+#[derive(Clone, Copy)]
+pub enum Instance {
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+}
+
+impl Instance {
+    fn ident(&self) -> String {
+        match self {
+            Instance::A => "gpioa",
+            Instance::B => "gpiob",
+            Instance::C => "gpioc",
+            Instance::D => "gpiod",
+            Instance::E => "gpioe",
+            Instance::F => "gpiof",
+            Instance::G => "gpiog",
+        }
+        .to_string()
+    }
+
+    fn base_addr(&self) -> u32 {
+        match self {
+            Instance::A => 0x4800_0000,
+            Instance::B => 0x4800_0400,
+            Instance::C => 0x4800_0800,
+            Instance::D => 0x4800_0c00,
+            Instance::E => 0x4800_1000,
+            Instance::F => 0x4800_1400,
+            Instance::G => 0x4800_1800,
+        }
+    }
+}
+
+pub fn generate(instance: Instance) -> Peripheral {
+    Peripheral::new(
+        instance.ident(),
+        instance.base_addr(),
+        [
+            moder::generate(instance),
+            otyper::generate(),
+            ospeedr::generate(instance),
+            pupdr::generate(instance),
+            idr::generate(),
+            odr::generate(),
+            // bsrr::generate(), // TODO: requires "effects"
+            // lckr::generate(), // TODO
+            afr::generate(afr::Instance::L),
+            afr::generate(afr::Instance::H),
+            // brr::generate(), // TODO: requires "effects"
+        ],
+    )
+    .entitlements([Entitlement::to(format!(
+        "rcc::ahb2enr::{}en::Enabled",
+        instance.ident()
+    ))])
+}

--- a/g4/model/src/gpio/afr.rs
+++ b/g4/model/src/gpio/afr.rs
@@ -1,0 +1,38 @@
+pub mod afsel;
+
+use proto_hal_build::ir::structures::register::Register;
+
+#[derive(Clone, Copy)]
+pub enum Instance {
+    L,
+    H,
+}
+
+impl Instance {
+    pub fn ident(&self) -> String {
+        match self {
+            Instance::L => "afrl",
+            Instance::H => "afrh",
+        }
+        .to_string()
+    }
+
+    pub fn offset(&self) -> u32 {
+        match self {
+            Instance::L => 0x20,
+            Instance::H => 0x24,
+        }
+    }
+}
+
+pub fn generate(instance: Instance) -> Register {
+    Register::new(
+        instance.ident(),
+        instance.offset(),
+        match instance {
+            Instance::L => 0..8,
+            Instance::H => 8..16,
+        }
+        .map(afsel::generate),
+    )
+}

--- a/g4/model/src/gpio/afr/afsel.rs
+++ b/g4/model/src/gpio/afr/afsel.rs
@@ -1,0 +1,19 @@
+use proto_hal_build::ir::{
+    access::Access,
+    structures::{
+        field::{Field, Numericity},
+        variant::Variant,
+    },
+};
+
+pub fn generate(x: u8) -> Field {
+    Field::new(
+        format!("afsel{x}"),
+        (x % 8) * 4,
+        4,
+        Access::read_write(Numericity::enumerated(
+            (0..16).map(|i| Variant::new(format!("AF{i}"), i)),
+        )),
+    )
+    .reset("AF0")
+}

--- a/g4/model/src/gpio/idr.rs
+++ b/g4/model/src/gpio/idr.rs
@@ -1,0 +1,7 @@
+pub mod id;
+
+use proto_hal_build::ir::structures::register::Register;
+
+pub fn generate() -> Register {
+    Register::new("idr", 0x10, (0..16).map(id::generate))
+}

--- a/g4/model/src/gpio/idr/id.rs
+++ b/g4/model/src/gpio/idr/id.rs
@@ -1,0 +1,19 @@
+use proto_hal_build::ir::{
+    access::Access,
+    structures::{
+        field::{Field, Numericity},
+        variant::Variant,
+    },
+};
+
+pub fn generate(i: u8) -> Field {
+    Field::new(
+        format!("id{i}"),
+        i,
+        1,
+        Access::read(Numericity::enumerated([
+            Variant::new("Low", 0),
+            Variant::new("High", 1),
+        ])),
+    )
+}

--- a/g4/model/src/gpio/moder.rs
+++ b/g4/model/src/gpio/moder.rs
@@ -1,0 +1,12 @@
+pub mod mode;
+
+use proto_hal_build::ir::structures::register::Register;
+
+use crate::gpio::Instance;
+
+pub fn generate(instance: Instance) -> Register {
+    Register::new("moder", 0, (0..16).map(|x| mode::generate(x, instance))).docs([
+        "*Note: It is recommended to set PB8 to a different mode than the analog one to \
+        limit the consumption that would occur if the pin is left unconnected.*",
+    ])
+}

--- a/g4/model/src/gpio/moder/mode.rs
+++ b/g4/model/src/gpio/moder/mode.rs
@@ -1,0 +1,27 @@
+use proto_hal_build::ir::{
+    access::Access,
+    structures::{
+        field::{Field, Numericity},
+        variant::Variant,
+    },
+};
+
+use crate::gpio::Instance;
+
+pub fn generate(i: u8, instance: Instance) -> Field {
+    Field::new(
+        format!("mode{i}"),
+        i * 2,
+        2,
+        Access::read_write(Numericity::enumerated([
+            Variant::new("Input", 0),
+            Variant::new("Output", 1),
+            Variant::new("Alternate", 2),
+            Variant::new("Analog", 3),
+        ])),
+    )
+    .reset(match (instance, i) {
+        (Instance::A, 14 | 15) | (Instance::B, 3 | 4) => "Alternate",
+        _ => "Input",
+    })
+}

--- a/g4/model/src/gpio/odr.rs
+++ b/g4/model/src/gpio/odr.rs
@@ -1,0 +1,7 @@
+pub mod od;
+
+use proto_hal_build::ir::structures::register::Register;
+
+pub fn generate() -> Register {
+    Register::new("odr", 0x14, (0..16).map(od::generate))
+}

--- a/g4/model/src/gpio/odr/od.rs
+++ b/g4/model/src/gpio/odr/od.rs
@@ -1,0 +1,20 @@
+use proto_hal_build::ir::{
+    access::Access,
+    structures::{
+        field::{Field, Numericity},
+        variant::Variant,
+    },
+};
+
+pub fn generate(i: u8) -> Field {
+    Field::new(
+        format!("od{i}"),
+        i,
+        1,
+        Access::read_write(Numericity::enumerated([
+            Variant::new("Low", 0),
+            Variant::new("High", 1),
+        ])),
+    )
+    .reset("Low")
+}

--- a/g4/model/src/gpio/ospeedr.rs
+++ b/g4/model/src/gpio/ospeedr.rs
@@ -1,0 +1,9 @@
+pub mod ospeed;
+
+use proto_hal_build::ir::structures::register::Register;
+
+use crate::gpio::Instance;
+
+pub fn generate(instance: Instance) -> Register {
+    Register::new("ospeedr", 8, (0..16).map(|x| ospeed::generate(x, instance)))
+}

--- a/g4/model/src/gpio/ospeedr/ospeed.rs
+++ b/g4/model/src/gpio/ospeedr/ospeed.rs
@@ -1,0 +1,27 @@
+use proto_hal_build::ir::{
+    access::Access,
+    structures::{
+        field::{Field, Numericity},
+        variant::Variant,
+    },
+};
+
+use crate::gpio::Instance;
+
+pub fn generate(i: u8, instance: Instance) -> Field {
+    Field::new(
+        format!("ospeed{i}"),
+        i * 2,
+        2,
+        Access::read_write(Numericity::enumerated([
+            Variant::new("Low", 0),
+            Variant::new("Medium", 1),
+            Variant::new("High", 2),
+            Variant::new("VeryHigh", 3),
+        ])),
+    )
+    .reset(match (instance, i) {
+        (Instance::A, 13) => "VeryHigh",
+        _ => "Low",
+    })
+}

--- a/g4/model/src/gpio/otyper.rs
+++ b/g4/model/src/gpio/otyper.rs
@@ -1,0 +1,7 @@
+pub mod ot;
+
+use proto_hal_build::ir::structures::register::Register;
+
+pub fn generate() -> Register {
+    Register::new("otyper", 4, (0..16).map(ot::generate))
+}

--- a/g4/model/src/gpio/otyper/ot.rs
+++ b/g4/model/src/gpio/otyper/ot.rs
@@ -6,15 +6,15 @@ use proto_hal_build::ir::{
     },
 };
 
-pub fn generate() -> Field {
+pub fn generate(i: u8) -> Field {
     Field::new(
-        "cordicen",
-        3,
+        format!("ot{i}"),
+        i,
         1,
         Access::read_write(Numericity::enumerated([
-            Variant::new("Disabled", 0),
-            Variant::new("Enabled", 1),
+            Variant::new("PushPull", 0),
+            Variant::new("OpenDrain", 1),
         ])),
     )
-    .reset("Disabled")
+    .reset("PushPull")
 }

--- a/g4/model/src/gpio/pupdr.rs
+++ b/g4/model/src/gpio/pupdr.rs
@@ -1,0 +1,9 @@
+pub mod pupd;
+
+use proto_hal_build::ir::structures::register::Register;
+
+use crate::gpio::Instance;
+
+pub fn generate(instance: Instance) -> Register {
+    Register::new("pupdr", 0xc, (0..16).map(|x| pupd::generate(x, instance)))
+}

--- a/g4/model/src/gpio/pupdr/pupd.rs
+++ b/g4/model/src/gpio/pupdr/pupd.rs
@@ -1,0 +1,27 @@
+use proto_hal_build::ir::{
+    access::Access,
+    structures::{
+        field::{Field, Numericity},
+        variant::Variant,
+    },
+};
+
+use crate::gpio::Instance;
+
+pub fn generate(i: u8, instance: Instance) -> Field {
+    Field::new(
+        format!("pupd{i}"),
+        i * 2,
+        2,
+        Access::read_write(Numericity::enumerated([
+            Variant::new("Floating", 0),
+            Variant::new("PullUp", 1),
+            Variant::new("PullDown", 2),
+        ])),
+    )
+    .reset(match (instance, i) {
+        (Instance::A, 13 | 15) | (Instance::B, 4) => "PullUp",
+        (Instance::A, 14) => "PullDown",
+        _ => "Floating",
+    })
+}

--- a/g4/model/src/lib.rs
+++ b/g4/model/src/lib.rs
@@ -1,10 +1,11 @@
+pub mod cordic;
+pub mod gpio;
+pub mod rcc;
+
 use proto_hal_build::ir::{
     structures::{hal::Hal, interrupts::Interrupt},
     utils::diagnostic::Diagnostics,
 };
-
-pub mod cordic;
-pub mod rcc;
 
 #[derive(Debug)]
 pub enum DeviceVariant {
@@ -23,7 +24,17 @@ pub fn generate(variant: DeviceVariant) -> Result<Hal, Diagnostics> {
         }
     };
 
-    let hal = Hal::new([rcc::generate(), cordic::generate()]).interrupts([
+    let hal = Hal::new([
+        rcc::generate(),
+        gpio::generate(gpio::Instance::A),
+        gpio::generate(gpio::Instance::B),
+        gpio::generate(gpio::Instance::C),
+        gpio::generate(gpio::Instance::D),
+        gpio::generate(gpio::Instance::E),
+        gpio::generate(gpio::Instance::F),
+        cordic::generate(),
+    ])
+    .interrupts([
         Interrupt::handler("WWDG").docs(["Window Watchdog"]),
         Interrupt::handler("PVD_PVM").docs(["PVD through EXTI line detection"]),
         Interrupt::handler("RTC_TAMP_CSS_LSE"),

--- a/g4/model/src/rcc.rs
+++ b/g4/model/src/rcc.rs
@@ -1,7 +1,14 @@
+pub mod ahbenr;
+
 use proto_hal_build::ir::structures::peripheral::Peripheral;
 
-pub mod ahb1enr;
-
 pub fn generate() -> Peripheral {
-    Peripheral::new("rcc", 0x4002_1000, [ahb1enr::generate()])
+    Peripheral::new(
+        "rcc",
+        0x4002_1000,
+        [
+            ahbenr::generate(ahbenr::Instance::I1),
+            ahbenr::generate(ahbenr::Instance::I2),
+        ],
+    )
 }

--- a/g4/model/src/rcc/ahb1enr.rs
+++ b/g4/model/src/rcc/ahb1enr.rs
@@ -1,7 +1,0 @@
-use proto_hal_build::ir::structures::register::Register;
-
-pub mod cordicen;
-
-pub fn generate() -> Register {
-    Register::new("ahb1enr", 0x48, [cordicen::generate()])
-}

--- a/g4/model/src/rcc/ahbenr.rs
+++ b/g4/model/src/rcc/ahbenr.rs
@@ -1,0 +1,61 @@
+pub mod en;
+
+use proto_hal_build::ir::structures::register::Register;
+
+#[derive(Clone, Copy)]
+pub enum Instance {
+    I1,
+    I2,
+}
+
+impl Instance {
+    fn ident(&self) -> String {
+        match self {
+            Instance::I1 => "ahb1enr",
+            Instance::I2 => "ahb2enr",
+        }
+        .to_string()
+    }
+
+    fn offset(&self) -> u32 {
+        match self {
+            Instance::I1 => 0x48,
+            Instance::I2 => 0x4c,
+        }
+    }
+}
+
+pub fn generate(instance: Instance) -> Register {
+    Register::new(
+        instance.ident(),
+        instance.offset(),
+        match instance {
+            Instance::I1 => vec![
+                en::generate("dma1en", 0),
+                en::generate("dam2en", 1),
+                en::generate("dammux1en", 2),
+                en::generate("cordicen", 3),
+                en::generate("fmacen", 4),
+                en::generate("flashen", 8).reset("Enabled"),
+                en::generate("crcen", 12),
+            ],
+            Instance::I2 => vec![
+                en::generate("gpioaen", 0),
+                en::generate("gpioben", 1),
+                en::generate("gpiocen", 2),
+                en::generate("gpioden", 3),
+                en::generate("gpioeen", 4),
+                en::generate("gpiofen", 5),
+                en::generate("gpiogen", 6),
+                en::generate("adc12en", 13),
+                en::generate("adc345en", 14),
+                en::generate("dac1en", 16),
+                en::generate("dac2en", 17),
+                en::generate("dac3en", 18),
+                en::generate("dac4en", 19),
+                en::generate("aesen", 24),
+                en::generate("rngen", 26),
+            ],
+        },
+    )
+}

--- a/g4/model/src/rcc/ahbenr/en.rs
+++ b/g4/model/src/rcc/ahbenr/en.rs
@@ -1,0 +1,20 @@
+use proto_hal_build::ir::{
+    access::Access,
+    structures::{
+        field::{Field, Numericity},
+        variant::Variant,
+    },
+};
+
+pub fn generate(ident: impl AsRef<str>, offset: u8) -> Field {
+    Field::new(
+        ident,
+        offset,
+        1,
+        Access::read_write(Numericity::enumerated([
+            Variant::new("Disabled", 0),
+            Variant::new("Enabled", 1),
+        ])),
+    )
+    .reset("Disabled")
+}

--- a/g4/out/Cargo.lock
+++ b/g4/out/Cargo.lock
@@ -325,7 +325,7 @@ dependencies = [
 [[package]]
 name = "ir"
 version = "0.1.0"
-source = "git+https://github.com/adinack/proto-hal?branch=main#e071e242a055f863acb2eb213a58cccf54841ad5"
+source = "git+https://github.com/adinack/proto-hal?branch=main#a9ca6f2310d803998921bb72e0d72b331fc6ccf5"
 dependencies = [
  "Inflector",
  "colored",
@@ -490,7 +490,7 @@ checksum = "302c525e16613efd9c9a684c096503d9dc662f7feb6b6c40e59303b4e2c4c113"
 [[package]]
 name = "proto-hal"
 version = "0.1.0"
-source = "git+https://github.com/adinack/proto-hal?branch=main#e071e242a055f863acb2eb213a58cccf54841ad5"
+source = "git+https://github.com/adinack/proto-hal?branch=main#a9ca6f2310d803998921bb72e0d72b331fc6ccf5"
 dependencies = [
  "arbitrary-int",
 ]
@@ -498,7 +498,7 @@ dependencies = [
 [[package]]
 name = "proto-hal-build"
 version = "0.1.0"
-source = "git+https://github.com/adinack/proto-hal?branch=main#e071e242a055f863acb2eb213a58cccf54841ad5"
+source = "git+https://github.com/adinack/proto-hal?branch=main#a9ca6f2310d803998921bb72e0d72b331fc6ccf5"
 dependencies = [
  "colored",
  "ir",


### PR DESCRIPTION
As proto-hal continues to become more feature rich, it is easier to add peripheral definitions. As proto-hal is now, there is enough to implement a large majority of the GPIO functionality.

Note: It has become clear to me that the compilation time of the generated HALs is large and very quickly becomes inconvenient. Feature gates for each peripheral can mitigate this, and I'm hoping that the cache is smart enough to keep compile times down during incremental builds, but I should also think about architectural changes that can reduce the amount of work the compiler has to do.

With this change, the generated HAL is well over 300,000 lines of code, according to the compiler timings, very little is spent producing the code, with most being spent compiling the generated code.