### PR TITLE
model: convenience macros

### DIFF
--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -9,3 +9,4 @@ cmpm = { package = "cortex-m-spa-model", git = "https://github.com/adinack/corte
 enum-iterator = "2.3.0"
 phm = { package = "proto-hal-model", git = "https://github.com/adinack/proto-hal" }
 quote = "1.0.45"
+model-macros = { package = "proto-hal-model-macros", git = "https://github.com/adinack/proto-hal" }

--- a/model/src/devices/c0/gpio.rs
+++ b/model/src/devices/c0/gpio.rs
@@ -13,20 +13,20 @@ use crate::devices::c0::Variant;
 
 #[derive(Clone, Copy)]
 pub struct Output {
-    pub moder: moder::Output,
-    pub otyper: otyper::Output,
-    pub ospeedr: ospeedr::OutputWithVeryHigh,
-    pub pupdr: pupdr::Output,
-    pub odr: odr::Output,
-    pub afrl: afr::Output,
-    pub afrh: afr::Output,
+    pub moder: moder::Full,
+    pub otyper: otyper::Full,
+    pub ospeedr: ospeedr::FullWithVeryHigh,
+    pub pupdr: pupdr::Full,
+    pub odr: odr::Full,
+    pub afrl: afr::Full,
+    pub afrh: afr::Full,
 }
 
 pub fn gpio(
     composition: &mut Composition,
     variant: &Variant,
     instance: Instance,
-    gpioen: en::Output,
+    gpioen: en::EnSchema,
 ) -> Output {
     let mut gpio = composition.gpio(
         instance,

--- a/model/src/devices/c0/rcc/ahbenr.rs
+++ b/model/src/devices/c0/rcc/ahbenr.rs
@@ -2,11 +2,11 @@ use crate::peripherals::{prelude::*, rcc::enr::en};
 use phm::model::PeripheralEntry;
 
 pub struct Output {
-    pub dma1en: en::Output,
+    pub dma1en: en::EnSchema,
 
-    pub flashen: en::Output,
+    pub flashen: en::EnSchema,
 
-    pub crcen: en::Output,
+    pub crcen: en::EnSchema,
 }
 
 pub fn ahbenr<'cx>(rcc: &mut PeripheralEntry<'cx>) -> Output {

--- a/model/src/devices/c0/rcc/iopenr.rs
+++ b/model/src/devices/c0/rcc/iopenr.rs
@@ -2,12 +2,12 @@ use crate::peripherals::{prelude::*, rcc::enr::en};
 use phm::model::PeripheralEntry;
 
 pub struct Output {
-    pub gpioaen: en::Output,
-    pub gpioben: en::Output,
-    pub gpiocen: en::Output,
-    pub gpioden: en::Output,
+    pub gpioaen: en::EnSchema,
+    pub gpioben: en::EnSchema,
+    pub gpiocen: en::EnSchema,
+    pub gpioden: en::EnSchema,
 
-    pub gpiofen: en::Output,
+    pub gpiofen: en::EnSchema,
 }
 
 pub fn iopenr<'cx>(rcc: &mut PeripheralEntry<'cx>) -> Output {

--- a/model/src/devices/g4/cordic.rs
+++ b/model/src/devices/g4/cordic.rs
@@ -9,7 +9,7 @@ use csr::csr;
 use rdata::rdata;
 use wdata::wdata;
 
-pub fn cordic(composition: &mut Composition, cordicen: en::Output) {
+pub fn cordic(composition: &mut Composition, cordicen: en::EnSchema) {
     let mut cordic = composition.add_peripheral(Peripheral::new("cordic", 0x4002_0c00));
 
     cordic.ontological_entitlements([[cordicen.enabled]]);

--- a/model/src/devices/g4/crc.rs
+++ b/model/src/devices/g4/crc.rs
@@ -13,7 +13,7 @@ use idr::idr;
 
 use crate::devices::g4::crc::{init::init, pol::pol};
 
-pub fn crc(composition: &mut Composition, crcen: en::Output) {
+pub fn crc(composition: &mut Composition, crcen: en::EnSchema) {
     let mut crc = composition.add_peripheral(Peripheral::new("crc", 0x4002_3000));
     crc.ontological_entitlements([[crcen.enabled]]);
 

--- a/model/src/devices/g4/dma.rs
+++ b/model/src/devices/g4/dma.rs
@@ -34,7 +34,7 @@ impl Instance {
     }
 }
 
-pub fn dma(composition: &mut Composition, instance: Instance, channels: u8, dmaen: en::Output) {
+pub fn dma(composition: &mut Composition, instance: Instance, channels: u8, dmaen: en::EnSchema) {
     let mut dma =
         composition.add_peripheral(Peripheral::new(instance.ident(), instance.base_addr()));
 

--- a/model/src/devices/g4/dmamux.rs
+++ b/model/src/devices/g4/dmamux.rs
@@ -12,7 +12,7 @@ pub mod rgcfr;
 pub mod rgcr;
 pub mod rgsr;
 
-pub fn dmamux(composition: &mut Composition, instances: u8, channels: u8, dmamux1en: en::Output) {
+pub fn dmamux(composition: &mut Composition, instances: u8, channels: u8, dmamux1en: en::EnSchema) {
     let mut dmamux = composition.add_peripheral(Peripheral::new("dmamux", 0x4002_0800));
 
     dmamux.ontological_entitlements([[dmamux1en.enabled]]);

--- a/model/src/devices/g4/gpio.rs
+++ b/model/src/devices/g4/gpio.rs
@@ -11,16 +11,16 @@ pub use crate::peripherals::gpio::Instance;
 
 #[derive(Clone, Copy)]
 pub struct Output {
-    pub moder: moder::Output,
-    pub otyper: otyper::Output,
-    pub ospeedr: ospeedr::OutputWithVeryHigh,
-    pub pupdr: pupdr::Output,
-    pub odr: odr::Output,
-    pub afrl: afr::Output,
-    pub afrh: afr::Output,
+    pub moder: moder::Full,
+    pub otyper: otyper::Full,
+    pub ospeedr: ospeedr::FullWithVeryHigh,
+    pub pupdr: pupdr::Full,
+    pub odr: odr::Full,
+    pub afrl: afr::Full,
+    pub afrh: afr::Full,
 }
 
-pub fn gpio(composition: &mut Composition, instance: Instance, gpioen: en::Output) -> Output {
+pub fn gpio(composition: &mut Composition, instance: Instance, gpioen: en::EnSchema) -> Output {
     let mut gpio = composition.gpio(
         instance,
         match instance {

--- a/model/src/devices/g4/rcc/ahb1enr.rs
+++ b/model/src/devices/g4/rcc/ahb1enr.rs
@@ -2,15 +2,15 @@ use crate::peripherals::{prelude::*, rcc::enr::en};
 use phm::model::PeripheralEntry;
 
 pub struct Output {
-    pub dma1en: en::Output,
-    pub dma2en: en::Output,
-    pub dmamux1en: en::Output,
-    pub cordicen: en::Output,
-    pub fmacen: en::Output,
+    pub dma1en: en::EnSchema,
+    pub dma2en: en::EnSchema,
+    pub dmamux1en: en::EnSchema,
+    pub cordicen: en::EnSchema,
+    pub fmacen: en::EnSchema,
 
-    pub flashen: en::Output,
+    pub flashen: en::EnSchema,
 
-    pub crcen: en::Output,
+    pub crcen: en::EnSchema,
 }
 
 pub fn ahb1enr<'cx>(rcc: &mut PeripheralEntry<'cx>) -> Output {

--- a/model/src/devices/g4/rcc/ahb2enr.rs
+++ b/model/src/devices/g4/rcc/ahb2enr.rs
@@ -2,25 +2,25 @@ use crate::peripherals::{prelude::*, rcc::enr::en};
 use phm::model::PeripheralEntry;
 
 pub struct Output {
-    pub gpioaen: en::Output,
-    pub gpioben: en::Output,
-    pub gpiocen: en::Output,
-    pub gpioden: en::Output,
-    pub gpioeen: en::Output,
-    pub gpiofen: en::Output,
-    pub gpiogen: en::Output,
+    pub gpioaen: en::EnSchema,
+    pub gpioben: en::EnSchema,
+    pub gpiocen: en::EnSchema,
+    pub gpioden: en::EnSchema,
+    pub gpioeen: en::EnSchema,
+    pub gpiofen: en::EnSchema,
+    pub gpiogen: en::EnSchema,
 
-    pub adc12en: en::Output,
-    pub adc345en: en::Output,
+    pub adc12en: en::EnSchema,
+    pub adc345en: en::EnSchema,
 
-    pub dac1en: en::Output,
-    pub dac2en: en::Output,
-    pub dac3en: en::Output,
-    pub dac4en: en::Output,
+    pub dac1en: en::EnSchema,
+    pub dac2en: en::EnSchema,
+    pub dac3en: en::EnSchema,
+    pub dac4en: en::EnSchema,
 
-    pub aesen: en::Output,
+    pub aesen: en::EnSchema,
 
-    pub rngen: en::Output,
+    pub rngen: en::EnSchema,
 }
 
 pub fn ahb2enr<'cx>(rcc: &mut PeripheralEntry<'cx>) -> Output {

--- a/model/src/devices/g4/rcc/apb2enr.rs
+++ b/model/src/devices/g4/rcc/apb2enr.rs
@@ -2,21 +2,21 @@ use crate::peripherals::{prelude::*, rcc::enr::en};
 use phm::model::PeripheralEntry;
 
 pub struct Output {
-    pub syscfgen: en::Output,
+    pub syscfgen: en::EnSchema,
 
-    pub tim1en: en::Output,
-    pub spi1en: en::Output,
-    pub tim8en: en::Output,
-    pub usart1en: en::Output,
-    pub spi4en: en::Output,
-    pub tim15en: en::Output,
-    pub tim16en: en::Output,
-    pub tim17en: en::Output,
+    pub tim1en: en::EnSchema,
+    pub spi1en: en::EnSchema,
+    pub tim8en: en::EnSchema,
+    pub usart1en: en::EnSchema,
+    pub spi4en: en::EnSchema,
+    pub tim15en: en::EnSchema,
+    pub tim16en: en::EnSchema,
+    pub tim17en: en::EnSchema,
 
-    pub tim20en: en::Output,
-    pub sai1en: en::Output,
+    pub tim20en: en::EnSchema,
+    pub sai1en: en::EnSchema,
 
-    pub hrtim1en: en::Output,
+    pub hrtim1en: en::EnSchema,
 }
 
 pub fn apb2enr<'cx>(rcc: &mut PeripheralEntry<'cx>) -> Output {

--- a/model/src/devices/g4/syscfg.rs
+++ b/model/src/devices/g4/syscfg.rs
@@ -5,7 +5,7 @@ use phm::{Composition, Peripheral};
 
 use crate::devices::g4::syscfg::exticr::exticr;
 
-pub fn syscfg(composition: &mut Composition, syscfgen: en::Output) {
+pub fn syscfg(composition: &mut Composition, syscfgen: en::EnSchema) {
     let mut syscfg = composition.add_peripheral(
         Peripheral::new("syscfg", 0x4001_0000).docs(["This peripheral is incomplete."]),
     );

--- a/model/src/devices/g4/syscfg/exticr/exti.rs
+++ b/model/src/devices/g4/syscfg/exticr/exti.rs
@@ -1,7 +1,7 @@
 use phm::{Field, Variant, model::RegisterEntry};
 
 pub fn exti<'cx>(exticr: &mut RegisterEntry<'cx>, i: u8) {
-    let mut exti = exticr.add_store_field(Field::new(format!("exti{i}"), (i % 4) * 4, 4));
+    let mut exti = exticr.add_store_field(Field::new_indexed_wrapping(format!("exti{i}"), i, 4, 4));
 
     exti.add_variant(Variant::new("PA", 0));
     exti.add_variant(Variant::new("PB", 1));

--- a/model/src/devices/g4/vrefbuf.rs
+++ b/model/src/devices/g4/vrefbuf.rs
@@ -5,7 +5,7 @@ use phm::{Composition, Peripheral};
 
 use crate::devices::g4::vrefbuf::csr::csr;
 
-pub fn vrefbuf(composition: &mut Composition, syscfgen: en::Output) {
+pub fn vrefbuf(composition: &mut Composition, syscfgen: en::EnSchema) {
     let mut vrefbuf = composition.add_peripheral(Peripheral::new("vrefbuf", 0x4001_0030));
 
     vrefbuf.ontological_entitlements([[syscfgen.enabled]]);

--- a/model/src/peripherals/gpio.rs
+++ b/model/src/peripherals/gpio.rs
@@ -1,10 +1,9 @@
-//! GPIO structures and model component helpers.
-//!
 //! References:
 //! - RM0440
 //! - RM0490
 
-use phm::{Composition, Peripheral, model::PeripheralEntry};
+use model_macros::peripheral;
+use phm::Peripheral;
 
 use crate::peripherals::rcc::enr::en;
 
@@ -41,28 +40,16 @@ impl Instance {
     }
 }
 
-/// Device model compositions implement this trait to attach GPIO peripherals.
-pub trait Gpio {
-    /// Add a GPIO peripheral to this composition.
-    fn gpio<'ncx>(
-        &'ncx mut self,
-        instance: Instance,
-        base_addr: u32,
-        en: en::Output,
-    ) -> PeripheralEntry<'ncx>;
-}
+peripheral! {
+    /// Attach GPIO peripherals to device model compositions.
+    Gpio {
+        /// Attach a GPIO peripheral to this composition.
+        gpio(instance: Instance, base_addr: u32, en: en::EnSchema) {
+            let mut gpio = self.add_peripheral(Peripheral::new(instance.name(), base_addr));
 
-impl Gpio for Composition {
-    fn gpio<'ncx>(
-        &'ncx mut self,
-        instance: Instance,
-        base_addr: u32,
-        en: en::Output,
-    ) -> PeripheralEntry<'ncx> {
-        let mut gpio = self.add_peripheral(Peripheral::new(instance.name(), base_addr));
+            gpio.ontological_entitlements([[en.enabled]]);
 
-        gpio.ontological_entitlements([[en.enabled]]);
-
-        gpio
+            gpio
+        }
     }
 }

--- a/model/src/peripherals/gpio/afr.rs
+++ b/model/src/peripherals/gpio/afr.rs
@@ -4,74 +4,58 @@
 //!
 //! Each Alternate Function Select field contains 16 variants AF0 through AF15.
 
-use phm::{
-    Field, Register,
-    field::access,
-    model::{FieldEntry, PeripheralEntry, RegisterEntry},
-};
+use model_macros::{field, register};
+use phm::{Field, Register};
 
-/// GPIO peripherals implement this trait to attach Alternate Function registers.
-pub trait Afr {
-    /// Add a lower Alternate Function register to this peripheral.
-    fn afrl<'ncx>(&'ncx mut self, offset: u32) -> RegisterEntry<'ncx>;
-
-    /// Add an upper Alternate Function register to this peripheral.
-    fn afrh<'ncx>(&'ncx mut self, offset: u32) -> RegisterEntry<'ncx>;
-}
-
-impl<'cx> Afr for PeripheralEntry<'cx> {
-    fn afrl<'ncx>(&'ncx mut self, offset: u32) -> RegisterEntry<'ncx> {
-        afr(self, "afrl", offset)
-    }
-
-    fn afrh<'ncx>(&'ncx mut self, offset: u32) -> RegisterEntry<'ncx> {
-        afr(self, "afrh", offset)
-    }
-}
-
-fn afr<'cx, 'ncx>(
-    afr: &'ncx mut PeripheralEntry<'cx>,
-    name: &str,
-    offset: u32,
-) -> RegisterEntry<'ncx> {
-    afr.add_register(Register::new(name, offset).reset(0))
-}
-
-/// Alternate Function registers implement this trait to attach Alternate Function Selection fields.
-pub trait Afsel {
-    /// Add an Alternate Function Selection field to this register.
-    fn afsel<'ncx>(&'ncx mut self, position: u8) -> FieldEntry<'ncx, access::Store>;
-}
-
-impl<'cx> Afsel for RegisterEntry<'cx> {
-    fn afsel<'ncx>(&'ncx mut self, position: u8) -> FieldEntry<'ncx, access::Store> {
-        self.add_store_field(Field::new(
-            format!("afsel{position}"),
-            (position * 4) % 32,
-            4,
-        ))
-    }
-}
-
-pub type Output = [afsel::Output; 8];
-
-pub mod afsel {
-    use std::array;
-
-    use phm::{Entitlement, Variant, field::access, model::FieldEntry};
-
-    pub trait Afsel {
-        fn afsel(&mut self) -> Output;
-    }
-
-    impl<'cx> Afsel for FieldEntry<'cx, access::Store> {
-        fn afsel(&mut self) -> Output {
-            array::from_fn(|i| {
-                self.add_variant(Variant::new(format!("AF{i}"), i as _))
-                    .make_entitlement()
-            })
+register! {
+    /// Attach Alternate Function registers to GPIO peripherals.
+    Afr {
+        /// Attach a lower Alternate Function register to this peripheral.
+        afrl(offset: u32) {
+            self.add_register(Register::new("afrl", offset).reset(0))
+        }
+        /// Attach an upper Alternate Function register to this peripheral.
+        afrh(offset: u32) {
+            self.add_register(Register::new("afrh", offset).reset(0))
         }
     }
+}
 
-    pub type Output = [Entitlement; 16];
+field! {
+    /// Attach Alternate Function Selection fields to Alternate Function registers.
+    Afsel<Store> {
+        /// Attach an Alternate Function Selection field to this register.
+        ///
+        /// *Note: "position" is not the bit offset, but rather the index of the field.*
+        afsel(position: u8) {
+            self.add_store_field(Field::new_indexed(
+                format!("afsel{position}"),
+                position,
+                4,
+            ))
+        }
+    }
+}
+
+/// A full Alternate Function Selection register. This means the register contains 8 Alternate Function Selection fields.
+pub type Full = [afsel::AfselSchema; 8];
+
+pub mod afsel {
+    use model_macros::schema;
+    use phm::Variant;
+
+    schema! {
+        /// Attach Alternate Function Selection schemas to Alternate Function Selection fields.
+        Afsel<Store> {
+            /// Alternate Function Selection.
+            ///
+            /// There are 16 alternate functions (AF0-AF15).
+            afsel() {
+                /// A selected alternate function.
+                #[entitlement]
+                #[array(0..16, index_pattern = "x")]
+                afx: self.add_variant(Variant::new(format!("AF{x}"), x as _)),
+            }
+        }
+    }
 }

--- a/model/src/peripherals/gpio/idr.rs
+++ b/model/src/peripherals/gpio/idr.rs
@@ -2,49 +2,43 @@
 //!
 //! IDR registers contain fields which reflect the digital input state of the respective channels.
 
-use phm::{
-    Field, Register,
-    field::access,
-    model::{FieldEntry, PeripheralEntry, RegisterEntry},
-};
+use model_macros::{field, register};
+use phm::{Field, Register};
 
-/// GPIO peripherals implement this trait to attach Port Input Data registers.
-pub trait Idr {
-    /// Add a Port Input Data register to this peripheral.
-    fn idr<'ncx>(&'ncx mut self, offset: u32) -> RegisterEntry<'ncx>;
-}
-
-impl<'cx> Idr for PeripheralEntry<'cx> {
-    fn idr<'ncx>(&'ncx mut self, offset: u32) -> RegisterEntry<'ncx> {
-        self.add_register(Register::new("idr", offset))
+register! {
+    /// GPIO peripherals implement this trait to attach Port Input Data registers.
+    Idr {
+        /// Attach a Port Input Data register to this peripheral.
+        idr(offset: u32) {
+            self.add_register(Register::new("idr", offset))
+        }
     }
 }
 
-/// Port Input Data registers implement this trait to attach Input Data fields.
-pub trait Id {
-    /// Add an Input Data field to this register.
-    fn id<'ncx>(&'ncx mut self, position: u8) -> FieldEntry<'ncx, access::Read>;
-}
-
-impl<'cx> Id for RegisterEntry<'cx> {
-    fn id<'ncx>(&'ncx mut self, position: u8) -> FieldEntry<'ncx, access::Read> {
-        self.add_read_field(Field::new(format!("id{position}"), position, 1))
+field! {
+    /// Attach Input Data fields to Port Input Data registers.
+    Id<Read> {
+        /// Attach an Input Data field to this register.
+        id(position: u8) {
+            self.add_read_field(Field::new(format!("id{position}"), position, 1))
+        }
     }
 }
 
 pub mod id {
-    use phm::{Variant, field::access, model::FieldEntry};
+    use model_macros::schema;
+    use phm::Variant;
 
-    /// Port Input Data fields implement this trait to be appropriately populated.
-    pub trait Id {
-        /// Populate the Port Input Data field with the appropriate contents.
-        fn id(&mut self);
-    }
-
-    impl<'cx> Id for FieldEntry<'cx, access::Read> {
-        fn id(&mut self) {
-            self.add_variant(Variant::new("Low", 0));
-            self.add_variant(Variant::new("High", 1));
+    schema! {
+        /// Attach Input Data schemas to Input Data fields.
+        Id<Read> {
+            /// Input Data. The measured channel level (either LOW or HIGH).
+            id() {
+                /// The measured channel level is LOW.
+                low: self.add_variant(Variant::new("Low", 0)),
+                /// The measured channel level is HIGH.
+                high: self.add_variant(Variant::new("High", 1)),
+            }
         }
     }
 }

--- a/model/src/peripherals/gpio/moder.rs
+++ b/model/src/peripherals/gpio/moder.rs
@@ -11,71 +11,56 @@
 //! | Alternate  | 2    |
 //! | Analog     | 3    |
 
-use phm::{
-    Field, Register,
-    field::access,
-    model::{FieldEntry, PeripheralEntry, RegisterEntry},
-};
+use model_macros::{field, register};
+use phm::{Field, Register};
 
-/// GPIO peripherals implement this trait to attach Port Mode registers.
-pub trait Moder {
-    /// Add a Port Mode register to this peripheral.
-    fn moder<'ncx>(&'ncx mut self, offset: u32, reset: u32) -> RegisterEntry<'ncx>;
-}
-
-impl<'cx> Moder for PeripheralEntry<'cx> {
-    fn moder<'ncx>(&'ncx mut self, offset: u32, reset: u32) -> RegisterEntry<'ncx> {
-        self.add_register(Register::new("moder", offset).reset(reset))
-    }
-}
-
-/// Port Mode registers implement this trait to attach Mode fields.
-pub trait Mode {
-    /// Add a Mode field to this register.
-    fn mode<'ncx>(&'ncx mut self, position: u8) -> FieldEntry<'ncx, access::Store>;
-}
-
-impl<'cx> Mode for RegisterEntry<'cx> {
-    fn mode<'ncx>(&'ncx mut self, position: u8) -> FieldEntry<'ncx, access::Store> {
-        self.add_store_field(Field::new(format!("mode{position}"), position * 2, 2))
-    }
-}
-
-pub type Output = [mode::Output; 16];
-
-pub mod mode {
-    use phm::{Entitlement, Variant, field::access, model::FieldEntry};
-
-    /// Port Mode fields implement this trait to be appropriately populated.
-    pub trait Mode {
-        /// Populate the Port Mode field with the appropriate contents.
-        fn mode(&mut self) -> Output;
-    }
-
-    impl<'cx> Mode for FieldEntry<'cx, access::Store> {
-        fn mode(&mut self) -> Output {
-            Output {
-                input: self
-                    .add_variant(Variant::new("Input", 0))
-                    .make_entitlement(),
-                output: self
-                    .add_variant(Variant::new("Output", 1))
-                    .make_entitlement(),
-                alternate: self
-                    .add_variant(Variant::new("Alternate", 2))
-                    .make_entitlement(),
-                analog: self
-                    .add_variant(Variant::new("Analog", 3))
-                    .make_entitlement(),
-            }
+register! {
+    /// Attach Port Mode registers to GPIO peripherals.
+    Moder {
+        /// Attach a Port Mode register to this peripheral.
+        moder(offset: u32, reset: u32) {
+            self.add_register(Register::new("moder", offset).reset(reset))
         }
     }
+}
 
-    #[derive(Clone, Copy)]
-    pub struct Output {
-        pub input: Entitlement,
-        pub output: Entitlement,
-        pub alternate: Entitlement,
-        pub analog: Entitlement,
+field! {
+    /// Attach Mode fields to Port Mode registers.
+    Mode<Store> {
+        /// Attach a Mode field to this register.
+        mode(position: u8) {
+            self.add_store_field(Field::new(format!("mode{position}"), position * 2, 2))
+        }
+    }
+}
+
+/// A full Port Mode register. This means the register contains 16 mode fields.
+pub type Full = [mode::ModeSchema; 16];
+
+pub mod mode {
+    use model_macros::schema;
+    use phm::Variant;
+
+    schema! {
+        /// Attach Mode schemas to Mode fields.
+        Mode<Store> {
+            /// Mode.
+            ///
+            /// There are 4 modes:
+            /// 1. Input
+            /// 1. Output
+            /// 1. Alternate
+            /// 1. Analog
+            mode() {
+                #[entitlement]
+                input: self.add_variant(Variant::new("Input", 0)),
+                #[entitlement]
+                output: self.add_variant(Variant::new("Output", 1)),
+                #[entitlement]
+                alternate: self.add_variant(Variant::new("Alternate", 2)),
+                #[entitlement]
+                analog: self.add_variant(Variant::new("Analog", 3)),
+            }
+        }
     }
 }

--- a/model/src/peripherals/gpio/odr.rs
+++ b/model/src/peripherals/gpio/odr.rs
@@ -2,59 +2,48 @@
 //!
 //! ODR registers contain fields which reflect the digital output state of the respective channels.
 
-use phm::{
-    Field, Register,
-    field::access,
-    model::{FieldEntry, PeripheralEntry, RegisterEntry},
-};
+use model_macros::{field, register};
+use phm::{Field, Register};
 
-/// GPIO peripherals implement this trait to attach Port Output Data registers.
-pub trait Odr {
-    /// Add a Port Output Data register to this peripheral.
-    fn odr<'ncx>(&'ncx mut self, offset: u32) -> RegisterEntry<'ncx>;
-}
-
-impl<'cx> Odr for PeripheralEntry<'cx> {
-    fn odr<'ncx>(&'ncx mut self, offset: u32) -> RegisterEntry<'ncx> {
-        self.add_register(Register::new("odr", offset).reset(0))
-    }
-}
-
-/// Port Output Data registers implement this trait to attach Output Data fields.
-pub trait Od {
-    /// Add an Output Data field to this register.
-    fn od<'ncx>(&'ncx mut self, position: u8) -> FieldEntry<'ncx, access::Store>;
-}
-
-impl<'cx> Od for RegisterEntry<'cx> {
-    fn od<'ncx>(&'ncx mut self, position: u8) -> FieldEntry<'ncx, access::Store> {
-        self.add_store_field(Field::new(format!("od{position}"), position, 1))
-    }
-}
-
-pub type Output = [od::Output; 16];
-
-pub mod od {
-    use phm::{Entitlement, Variant, field::access, model::FieldEntry};
-
-    /// Port Output Data fields implement this trait to be appropriately populated.
-    pub trait Od {
-        /// Populate the Port Output Data field with the appropriate contents.
-        fn od(&mut self) -> Output;
-    }
-
-    impl<'cx> Od for FieldEntry<'cx, access::Store> {
-        fn od(&mut self) -> Output {
-            Output {
-                low: self.add_variant(Variant::new("Low", 0)).make_entitlement(),
-                high: self.add_variant(Variant::new("High", 1)).make_entitlement(),
-            }
+register! {
+    /// Attach Port Output Data registers to GPIO peripherals.
+    Odr {
+        /// Attach a Port Output Data register to this peripheral.
+        odr(offset: u32) {
+            self.add_register(Register::new("odr", offset).reset(0))
         }
     }
+}
 
-    #[derive(Clone, Copy)]
-    pub struct Output {
-        pub low: Entitlement,
-        pub high: Entitlement,
+field! {
+    /// Attach Output Data fields to Port Output Data registers.
+    Od<Store> {
+        /// Attach an Output Data field to this register.
+        od(position: u8) {
+            self.add_store_field(Field::new(format!("od{position}"), position, 1))
+        }
+    }
+}
+
+/// A full Port Output Data register. This means the register contains 16 Output data fields.
+pub type Full = [od::OdSchema; 16];
+
+pub mod od {
+    use model_macros::schema;
+    use phm::Variant;
+
+    schema! {
+        /// Attach Output Data schemas to Output Data fields.
+        Od<Store> {
+            /// Output Data. The configured channel level (either LOW or HIGH).
+            od() {
+                #[entitlement]
+                /// The configured channel level is LOW.
+                low: self.add_variant(Variant::new("Low", 0)),
+                #[entitlement]
+                /// The configured channel level is HIGH.
+                high: self.add_variant(Variant::new("High", 1)),
+            }
+        }
     }
 }

--- a/model/src/peripherals/gpio/ospeedr.rs
+++ b/model/src/peripherals/gpio/ospeedr.rs
@@ -11,92 +11,66 @@
 //! | High     | 2    |
 //! | VeryHigh | 3    |
 
-use phm::{
-    Field, Register,
-    field::access,
-    model::{FieldEntry, PeripheralEntry, RegisterEntry},
-};
+use model_macros::{field, register};
+use phm::{Field, Register};
 
-/// GPIO peripherals implement this trait to attach Port Output Speed registers.
-pub trait Ospeedr {
-    /// Add a Port Output Speed register to this peripheral.
-    fn ospeedr<'ncx>(&'ncx mut self, offset: u32, reset: u32) -> RegisterEntry<'ncx>;
-}
-
-impl<'cx> Ospeedr for PeripheralEntry<'cx> {
-    fn ospeedr<'ncx>(&'ncx mut self, offset: u32, reset: u32) -> RegisterEntry<'ncx> {
-        self.add_register(Register::new("ospeedr", offset).reset(reset))
+register! {
+    /// Attach Port Output Speed registers to GPIO peripherals.
+    Ospeedr {
+        /// Attach a Port Output Speed register to this peripheral.
+        ospeedr(offset: u32, reset: u32) {
+            self.add_register(Register::new("ospeedr", offset).reset(reset))
+        }
     }
 }
 
-/// Port Output Speed registers implement this trait to attach Output Speed fields.
-pub trait Ospeed {
-    /// Add an Output Speed field to this register.
-    fn ospeed<'ncx>(&'ncx mut self, position: u8) -> FieldEntry<'ncx, access::Store>;
-}
-
-impl<'cx> Ospeed for RegisterEntry<'cx> {
-    fn ospeed<'ncx>(&'ncx mut self, position: u8) -> FieldEntry<'ncx, access::Store> {
-        self.add_store_field(Field::new(format!("ospeed{position}"), position * 2, 2))
+field! {
+    /// Attach Output Speed fields to Port Output Speed registers.
+    Ospeed<Store> {
+        /// Attach an Output Speed field to this register.
+        ospeed(position: u8) {
+            self.add_store_field(Field::new(format!("ospeed{position}"), position * 2, 2))
+        }
     }
 }
 
-// Note: Heterogenous registers should be expressed ad hoc and these are purely for convenience.
-pub type Output = [ospeed::Output; 16];
-pub type OutputWithVeryHigh = [ospeed::OutputWithVeryHigh; 16];
+/// A full Poty Output Speed register. This means the register contains 16 Output Speed fields.
+pub type Full = [ospeed::OspeedSchema; 16];
+/// A full Port Output Speed register. This means the register contains 16 Output Speed fields (with
+/// [very high speed](ospeed::Ospeed::ospeed_with_very_high)).
+pub type FullWithVeryHigh = [ospeed::OspeedWithVeryHighSchema; 16];
 
 pub mod ospeed {
-    use phm::{Entitlement, Variant, field::access, model::FieldEntry};
+    use model_macros::schema;
+    use phm::Variant;
 
-    /// Port Output Speed fields implement this trait to be appropriately populated.
-    pub trait Ospeed {
-        /// Populate the Port Output Speed field with the appropriate contents.
-        fn ospeed_with_very_high(&mut self) -> OutputWithVeryHigh;
+    schema! {
+        /// Attach Output Speed schemas to Output Speed fields.
+        Ospeed<Store> {
+            /// Output Speed.
+            ///
+            /// This schema inherts from [`ospeed`](Ospeed::ospeed) and adds the `VeryHigh` speed variant.
+            ///
+            /// Some channels are incapable of this speed (*RM0490 § 8.5.3*).
+            #[inherits(ospeed)]
+            ospeed_with_very_high() {
+                /// Very high speed.
+                #[entitlement]
+                very_high: self.add_variant(Variant::new("VeryHigh", 3)),
+            }
 
-        /// Populate the Port Output Speed field with the appropriate contents.
-        ///
-        /// This method *omits* the "Very High" speed variant according to RM0490 § 8.5.3.
-        fn ospeed(&mut self) -> Output;
-    }
-
-    impl<'cx> Ospeed for FieldEntry<'cx, access::Store> {
-        fn ospeed_with_very_high(&mut self) -> OutputWithVeryHigh {
-            let output = self.ospeed();
-
-            OutputWithVeryHigh {
-                low: output.low,
-                medium: output.medium,
-                high: output.high,
-                veryhigh: self
-                    .add_variant(Variant::new("VeryHigh", 3))
-                    .make_entitlement(),
+            /// Output Speed.
+            ospeed() {
+                /// Low speed.
+                #[entitlement]
+                low: self.add_variant(Variant::new("Low", 0)),
+                /// Medium speed.
+                #[entitlement]
+                medium: self.add_variant(Variant::new("Medium", 1)),
+                /// High speed.
+                #[entitlement]
+                high: self.add_variant(Variant::new("High", 2)),
             }
         }
-
-        fn ospeed(&mut self) -> Output {
-            Output {
-                low: self.add_variant(Variant::new("Low", 0)).make_entitlement(),
-                medium: self
-                    .add_variant(Variant::new("Medium", 1))
-                    .make_entitlement(),
-                high: self.add_variant(Variant::new("High", 2)).make_entitlement(),
-            }
-        }
-    }
-
-    #[derive(Clone, Copy)]
-    pub struct OutputWithVeryHigh {
-        pub low: Entitlement,
-        pub medium: Entitlement,
-        pub high: Entitlement,
-        pub veryhigh: Entitlement,
-    }
-
-    /// The state outputs of [`Ospeed`] fields *except for* the "Very High" state.
-    #[derive(Clone, Copy)]
-    pub struct Output {
-        pub low: Entitlement,
-        pub medium: Entitlement,
-        pub high: Entitlement,
     }
 }

--- a/model/src/peripherals/gpio/otyper.rs
+++ b/model/src/peripherals/gpio/otyper.rs
@@ -9,63 +9,50 @@
 //! | Push-pull  | 0    |
 //! | Open-drain | 1    |
 
-use phm::{
-    Field, Register,
-    field::access,
-    model::{FieldEntry, PeripheralEntry, RegisterEntry},
-};
+use model_macros::{field, register};
+use phm::{Field, Register};
 
-/// GPIO peripherals implement this trait to attach Port Output Type registers.
-pub trait Otyper {
-    /// Add a Port Output Type register to this peripheral.
-    fn otyper<'ncx>(&'ncx mut self, offset: u32, reset: u32) -> RegisterEntry<'ncx>;
-}
-
-impl<'cx> Otyper for PeripheralEntry<'cx> {
-    fn otyper<'ncx>(&'ncx mut self, offset: u32, reset: u32) -> RegisterEntry<'ncx> {
-        self.add_register(Register::new("otyper", offset).reset(reset))
-    }
-}
-
-/// Port Output Type registers implement this trait to attach Output Type fields.
-pub trait Ot {
-    /// Add an Output Type field to this register.
-    fn ot<'ncx>(&'ncx mut self, position: u8) -> FieldEntry<'ncx, access::Store>;
-}
-
-impl<'cx> Ot for RegisterEntry<'cx> {
-    fn ot<'ncx>(&'ncx mut self, position: u8) -> FieldEntry<'ncx, access::Store> {
-        self.add_store_field(Field::new(format!("ot{position}"), position, 1))
-    }
-}
-
-pub type Output = [ot::Output; 16];
-
-pub mod ot {
-    use phm::{Entitlement, Variant, field::access, model::FieldEntry};
-
-    /// Port Output Type fields implement this trait to be appropriately populated.
-    pub trait Ot {
-        /// Populate the Port Output Type field with the appropriate contents.
-        fn ot(&mut self) -> Output;
-    }
-
-    impl<'cx> Ot for FieldEntry<'cx, access::Store> {
-        fn ot(&mut self) -> Output {
-            Output {
-                push_pull: self
-                    .add_variant(Variant::new("PushPull", 0))
-                    .make_entitlement(),
-                open_drain: self
-                    .add_variant(Variant::new("OpenDrain", 1))
-                    .make_entitlement(),
-            }
+register! {
+    /// Attach Port Output Type registers to GPIO peripherals.
+    Otyper {
+        /// Attach a Port Output Type register to this peripheral.
+        otyper(offset: u32, reset: u32) {
+            self.add_register(Register::new("otyper", offset).reset(reset))
         }
     }
+}
 
-    #[derive(Clone, Copy)]
-    pub struct Output {
-        pub push_pull: Entitlement,
-        pub open_drain: Entitlement,
+field! {
+    /// Attach Output Type fields to Port Output Type registers.
+    Ot<Store> {
+        /// Attach an Output Type field to this register.
+        ot(position: u8) {
+            self.add_store_field(Field::new(format!("ot{position}"), position, 1))
+        }
+    }
+}
+
+/// A full Port Output Type register. This means the register contains 16 Output Type fields.
+pub type Full = [ot::OtSchema; 16];
+
+pub mod ot {
+    use model_macros::schema;
+    use phm::Variant;
+
+    schema! {
+        /// Attach an Output Type schema to an Output Type field.
+        Ot<Store> {
+            /// Output Type.
+            ///
+            /// There are two output types:
+            /// - Push-Pull
+            /// - Open Drain
+            ot() {
+                #[entitlement]
+                push_pull: self.add_variant(Variant::new("PushPull", 0)),
+                #[entitlement]
+                open_drain: self.add_variant(Variant::new("OpenDrain", 1)),
+            }
+        }
     }
 }

--- a/model/src/peripherals/gpio/pupdr.rs
+++ b/model/src/peripherals/gpio/pupdr.rs
@@ -10,67 +10,53 @@
 //! | PullUp   | 1    |
 //! | PullDown | 2    |
 
-use phm::{
-    Field, Register,
-    field::access,
-    model::{FieldEntry, PeripheralEntry, RegisterEntry},
-};
+use model_macros::{field, register};
+use phm::{Field, Register};
 
-/// GPIO peripherals implement this trait to attach Port Pull-up/Pull-down registers.
-pub trait Pupdr {
-    /// Add a Port Pull-up/Pull-down register to this peripheral.
-    fn pupdr<'ncx>(&'ncx mut self, offset: u32, reset: u32) -> RegisterEntry<'ncx>;
-}
-
-impl<'cx> Pupdr for PeripheralEntry<'cx> {
-    fn pupdr<'ncx>(&'ncx mut self, offset: u32, reset: u32) -> RegisterEntry<'ncx> {
-        self.add_register(Register::new("pupdr", offset).reset(reset))
-    }
-}
-
-/// Port Pull-up/Pull-down registers implement this trait to attach Mode fields.
-pub trait Pupd {
-    /// Add a Pull-up/Pull-down field to this register.
-    fn pupd<'ncx>(&'ncx mut self, position: u8) -> FieldEntry<'ncx, access::Store>;
-}
-
-impl<'cx> Pupd for RegisterEntry<'cx> {
-    fn pupd<'ncx>(&'ncx mut self, position: u8) -> FieldEntry<'ncx, access::Store> {
-        self.add_store_field(Field::new(format!("pupd{position}"), position * 2, 2))
-    }
-}
-
-pub type Output = [pupd::Output; 16];
-
-pub mod pupd {
-    use phm::{Entitlement, Variant, field::access, model::FieldEntry};
-
-    /// Port Pull-up/Pull-down fields implement this trait to be appropriately populated.
-    pub trait Pupd {
-        /// Populate the Port Pull-up/Pull-down field with the appropriate contents.
-        fn pupd(&mut self) -> Output;
-    }
-
-    impl<'cx> Pupd for FieldEntry<'cx, access::Store> {
-        fn pupd(&mut self) -> Output {
-            Output {
-                floating: self
-                    .add_variant(Variant::new("Floating", 0))
-                    .make_entitlement(),
-                pullup: self
-                    .add_variant(Variant::new("PullUp", 1))
-                    .make_entitlement(),
-                pulldown: self
-                    .add_variant(Variant::new("PullDown", 2))
-                    .make_entitlement(),
-            }
+register! {
+    /// Attach Port Pull-up/Pull-down registers to PGIO peripherals.
+    Pupdr {
+        /// Attach a Port Pull-up/Pull-down register to this peripheral.
+        pupdr(offset: u32, reset: u32) {
+            self.add_register(Register::new("pupdr", offset).reset(reset))
         }
     }
+}
 
-    #[derive(Clone, Copy)]
-    pub struct Output {
-        pub floating: Entitlement,
-        pub pullup: Entitlement,
-        pub pulldown: Entitlement,
+field! {
+    /// Attach Pull-up/Pull-down fields to Port Pull-up/Pull-down registers.
+    Pupd<Store> {
+        /// Attach a Pull-up/Pull-down field to this register.
+        pupd(position: u8) {
+            self.add_store_field(Field::new_indexed(format!("pupd{position}"), position, 2))
+        }
+    }
+}
+
+/// A full Port Pull-up/Pull-down register. This means the register contains 16 Pull-up/Pull-down fields.
+pub type Full = [pupd::PupdSchema; 16];
+
+pub mod pupd {
+    use model_macros::schema;
+    use phm::Variant;
+
+    schema! {
+        /// Attach Pull-up/Pull-down schemas to Pull-up/Pull-down fields.
+        Pupd<Store> {
+            /// Pull-up/Pull-down.
+            ///
+            /// There are three pull-up/pull-down variants:
+            /// - Floating (no pull-up or pull-down)
+            /// - Pull Up
+            /// - Pull Down
+            pupd() {
+                #[entitlement]
+                floating: self.add_variant(Variant::new("Floating", 0)),
+                #[entitlement]
+                pullup: self.add_variant(Variant::new("PullUp", 1)),
+                #[entitlement]
+                pulldown: self.add_variant(Variant::new("PullDown", 2)),
+            }
+        }
     }
 }

--- a/model/src/peripherals/rcc/enr.rs
+++ b/model/src/peripherals/rcc/enr.rs
@@ -10,117 +10,77 @@
 //! | Disabled | 0    |
 //! | Enabled  | 1    |
 
-use phm::{
-    Field, Register,
-    field::access,
-    model::{FieldEntry, PeripheralEntry, RegisterEntry},
-};
-use quote::format_ident;
+use model_macros::{field, register};
+use phm::{Field, Register};
 
-/// Reset & Clock Control peripherals implement this trait to attach Peripheral Clock Enable registers.
-pub trait Enr {
-    /// Add a Peripheral Clock Enable register to this peripheral.
-    ///
-    /// *Note: The suffix "enr" is added to the provided name.*
-    fn enr<'ncx>(
-        &'ncx mut self,
-        name: impl AsRef<str>,
-        offset: u32,
-        reset: u32,
-        index: Option<usize>,
-    ) -> RegisterEntry<'ncx> {
-        let name = name.as_ref();
+register! {
+    /// Attach Peripheral Clock Enable registers to Reset & Clock Control peripherals.
+    Enr {
+        /// Attach a Peripheral Clock Enable register to this peripheral.
+        ///
+        /// *Note: The suffix "enr" is added to the provided name.*
+        enr(
+            name: impl AsRef<str>,
+            offset: u32,
+            reset: u32,
+            index: Option<usize>,
+        ) {
+            let name = name.as_ref();
 
-        self.enr_from_register(Register::new(name, offset).reset(reset), index)
-    }
+            let title = "peripheral clock enable register";
 
-    /// Add a Peripheral Clock Enable register to this peripheral given a [`Register`] component.
-    ///
-    /// *Note: The suffix "enr" is added to the provided name.*
-    fn enr_from_register<'ncx>(
-        &'ncx mut self,
-        register: Register,
-        index: Option<usize>,
-    ) -> RegisterEntry<'ncx>;
-}
-
-impl<'cx> Enr for PeripheralEntry<'cx> {
-    fn enr_from_register<'ncx>(
-        &'ncx mut self,
-        mut register: Register,
-        index: Option<usize>,
-    ) -> RegisterEntry<'ncx> {
-        let name = register.module_name();
-
-        if let Some(index) = index {
-            register.ident = format_ident!("{name}enr{index}");
-        } else {
-            register.ident = format_ident!("{name}enr");
+            self.add_register(Register::new(if let Some(index) = index {
+                format!("{name}enr{index}")
+            } else {
+                format!("{name}enr")
+            }, offset).reset(reset).docs([if let Some(index) = index {
+                format!("{name} {title} {index}.")
+            } else {
+                format!("{name} {title}.")
+            }]))
         }
-
-        let title = "peripheral clock enable register";
-
-        self.add_register(register.docs([if let Some(index) = index {
-            format!("{name} {title} {index}.")
-        } else {
-            format!("{name} {title}.")
-        }]))
     }
 }
 
-/// Peripheral Clock Enable registers implement this trait to attach Peripheral Clock Enable fields.
-pub trait En {
-    /// Add a Peripheral Clock Enable field to this register.
-    ///
-    /// *Note: The suffix "en" is added to the provided name.*
-    fn en<'ncx>(
-        &'ncx mut self,
-        name: impl AsRef<str>,
-        position: u8,
-    ) -> FieldEntry<'ncx, access::Store>;
-}
+field! {
+    /// Attach Peripheral Clock Enable fields to Peripheral Clock Enable registers.
+    En<Store> {
+        /// Attach a Peripheral Clock Enable field to this register.
+        ///
+        /// *Note: The suffix "en" is added to the provided name.*
+        en(name: impl AsRef<str>, position: u8) {
+            let name = name.as_ref();
 
-impl<'cx> En for RegisterEntry<'cx> {
-    fn en<'ncx>(
-        &'ncx mut self,
-        name: impl AsRef<str>,
-        position: u8,
-    ) -> FieldEntry<'ncx, access::Store> {
-        let name = name.as_ref();
-
-        self.add_store_field(
-            Field::new(format!("{name}en"), position, 1).docs([format!("{name} clock enable.")]),
-        )
+            self.add_store_field(
+                Field::new(format!("{name}en"), position, 1).docs([format!("{name} clock enable.")]),
+            )
+        }
     }
 }
 
 pub mod en {
-    use phm::{Entitlement, Variant, field::access, model::FieldEntry};
+    use model_macros::schema;
+    use phm::Variant;
 
-    /// Peripheral Clock Enable fields implement this trait to be appropriately populated.
-    pub trait En {
-        /// Populate the Peripheral Clock Enable field with the appropriate contents.
-        fn en(&mut self) -> Output;
-    }
+    schema! {
+        /// Attach Peripheral Clock Enable schemas to Peripheral Clock Enable Fields.
+        En<Store> {
+            /// | Variant  | Bits |
+            /// | -------- | ---- |
+            /// | Disabled | 0    |
+            /// | Enabled  | 1    |
+            en() {
+                /// The corresponding peripheral is disabled.
+                #[entitlement]
+                disabled: self.add_variant(Variant::new("Disabled", 0).docs(["Peripheral clock is disabled."])),
 
-    impl<'cx> En for FieldEntry<'cx, access::Store> {
-        fn en(&mut self) -> Output {
-            Output {
-                disabled: self
-                    .add_variant(
-                        Variant::new("Disabled", 0).docs(["Peripheral clock is disabled."]),
-                    )
-                    .make_entitlement(),
-                enabled: self
-                    .add_variant(Variant::new("Enabled", 1).docs(["Peripheral clock is enabled."]))
-                    .make_entitlement(),
+                /// The corresponding peripheral is enabled.
+                ///
+                /// *Note: On some devices there is a delay (usually measured in number of cycles on the respective bus
+                /// ) between this variant being set and the peripheral actually being enabled.*
+                #[entitlement]
+                enabled: self.add_variant(Variant::new("Enabled", 1).docs(["Peripheral clock is enabled."]))
             }
         }
-    }
-
-    #[derive(Clone, Copy)]
-    pub struct Output {
-        pub disabled: Entitlement,
-        pub enabled: Entitlement,
     }
 }


### PR DESCRIPTION
Begin migrating model components and definitions to using the new convenience macros.